### PR TITLE
Unescape performance improvement

### DIFF
--- a/lib/parser.ex
+++ b/lib/parser.ex
@@ -514,7 +514,7 @@ defmodule Antidote.Parser do
 
     defmacro escapeu_last(int, original, skip) do
       clauses = escapeu_last_clauses()
-      quote do
+      quote location: :keep do
         case unquote(int) do
           unquote(clauses ++ token_error_clause(original, skip, 6))
         end
@@ -523,7 +523,7 @@ defmodule Antidote.Parser do
 
     defmacro escapeu_first(int, last, rest, original, skip, stack, acc) do
       clauses = escapeu_first_clauses(last, rest, original, skip, stack, acc)
-      quote do
+      quote location: :keep do
         case unquote(int) do
           unquote(clauses ++ token_error_clause(original, skip, 6))
         end
@@ -559,7 +559,7 @@ defmodule Antidote.Parser do
     defmacro escapeu_surrogate(int, last, rest, original, skip, stack, acc,
              hi) do
       clauses = escapeu_surrogate_clauses(last, rest, original, skip, stack, acc, hi)
-      quote do
+      quote location: :keep do
         case unquote(int) do
           unquote(clauses ++ token_error_clause(original, skip, 12))
         end

--- a/lib/parser.ex
+++ b/lib/parser.ex
@@ -441,8 +441,7 @@ defmodule Antidote.Parser do
   end
 
   defmodule Unescape do
-
-    use Bitwise
+    import Bitwise
 
     @digits Enum.concat([?0..?9, ?A..?F, ?a..?f])
 

--- a/lib/parser.ex
+++ b/lib/parser.ex
@@ -447,11 +447,8 @@ defmodule Antidote.Parser do
     @digits Enum.concat([?0..?9, ?A..?F, ?a..?f])
 
     def unicode_escapes(chars1 \\ @digits, chars2 \\ @digits) do
-      for char1 <- chars1, char2 <- chars2,
-          char3 <- @digits, char4 <- @digits do
-        value = (char1 <<< 24) + (char2 <<< 16) + (char3 <<< 8) + char4
-        codepoint = (integer8(char1, char2) <<< 8) + integer8(char3, char4)
-        {value, codepoint}
+      for char1 <- chars1, char2 <- chars2 do
+        {(char1 <<< 8) + char2, integer8(char1, char2)}
       end
     end
 
@@ -463,17 +460,29 @@ defmodule Antidote.Parser do
     defp integer4(char) when char in ?A..?F, do: char - ?A + 10
     defp integer4(char) when char in ?a..?f, do: char - ?a + 10
 
-    defp escapeu_clauses(rest, original, skip, stack, acc) do
-      for {int, codepoint} <- unicode_escapes(),
-          not (codepoint in 0xDC00..0xDFFF) do
-        escapeu_clause(int, rest, original, skip, stack, acc, codepoint)
+    defp escapeu_last_clauses() do
+      for {int, last} <- unicode_escapes() do
+        [clause] =
+          quote do
+            unquote(int) -> unquote(last)
+          end
+        clause
       end
     end
 
-    defp escapeu_clause(int, rest, original, skip, stack, acc, codepoint)
-         when codepoint in 0xD800..0xDBFF do
-      min_char = <<(0x10000 + ((codepoint &&& 0x03FF) <<< 10))::utf8>>
-      <<hi::20, 0::4, 0b10::2, 0::6>> = min_char
+    defp escapeu_first_clauses(last, rest, original, skip, stack, acc) do
+      for {int, first} <- unicode_escapes(),
+          not (first in 0xDC..0xDF) do
+        escapeu_first_clause(int, first, last, rest, original, skip, stack, acc)
+      end
+    end
+
+    defp escapeu_first_clause(int, first, last, rest, original, skip, stack, acc)
+         when first in 0xD8..0xDB do
+      hi =
+        quote bind_quoted: [first: first, last: last] do
+          0x10000 + ((((first &&& 0x03) <<< 8) + last) <<< 10)
+        end
       args = [rest, original, skip, stack, acc, hi]
       [clause] =
         quote location: :keep do
@@ -482,26 +491,18 @@ defmodule Antidote.Parser do
       clause
     end
 
-    defp escapeu_clause(int, rest, original, skip, stack, acc, codepoint) do
+    defp escapeu_first_clause(int, first, last, rest, original, skip, stack, acc) do
       skip = quote do: (unquote(skip) + 6)
-      acc = quote do: [unquote(acc) | unquote(char(codepoint))]
+      acc =
+        quote bind_quoted: [acc: acc, first: first, last: last] do
+          [acc | <<((first <<< 8) + last)::utf8>>]
+        end
       args = [rest, original, skip, stack, acc, 0]
       [clause] =
         quote location: :keep do
           unquote(int) -> string(unquote_splicing(args))
         end
       clause
-    end
-
-    defp char(codepoint) do
-      case <<codepoint::utf8>> do
-        <<byte::8>> ->
-          [byte]
-        <<byte1::8, byte2::8>> ->
-          [byte1, byte2]
-        char ->
-          char
-      end
     end
 
     defp token_error_clause(original, skip, len) do
@@ -511,8 +512,8 @@ defmodule Antidote.Parser do
       end
     end
 
-    defmacro escapeu_case(int, rest, original, skip, stack, acc) do
-      clauses = escapeu_clauses(rest, original, skip, stack, acc)
+    defmacro escapeu_last(int, original, skip) do
+      clauses = escapeu_last_clauses()
       quote do
         case unquote(int) do
           unquote(clauses ++ token_error_clause(original, skip, 6))
@@ -520,34 +521,44 @@ defmodule Antidote.Parser do
       end
     end
 
-    defp escapeu_surrogate_clauses(rest, original, skip, stack, acc, hi) do
-      digits1 = 'Dd'
-      digits2 = Stream.concat([?C..?F, ?c..?f])
-      for {int, lo} <- unicode_escapes(digits1, digits2) do
-        escapeu_surrogate_clause(int, rest, original, skip, stack, acc, hi, lo)
+    defmacro escapeu_first(int, last, rest, original, skip, stack, acc) do
+      clauses = escapeu_first_clauses(last, rest, original, skip, stack, acc)
+      quote do
+        case unquote(int) do
+          unquote(clauses ++ token_error_clause(original, skip, 6))
+        end
       end
     end
 
-    defp escapeu_surrogate_clause(int, rest, original, skip, stack, acc,
-         hi, lo) do
+    defp escapeu_surrogate_clauses(last, rest, original, skip, stack, acc, hi) do
+      digits1 = 'Dd'
+      digits2 = Stream.concat([?C..?F, ?c..?f])
+      for {int, first} <- unicode_escapes(digits1, digits2) do
+        escapeu_surrogate_clause(int, first, last, rest, original, skip, stack,
+          acc, hi)
+      end
+    end
+
+    defp escapeu_surrogate_clause(int, first, last, rest, original, skip, stack,
+         acc, hi) do
       skip = quote do: unquote(skip) + 12
-      args = [rest, original, skip, stack]
-      # Get the 10 least significant bits from lo and split into 4 and 6 bits
-      lo1 = (lo &&& 0x03C0) >>> 6
-      lo2 = lo &&& 0x003F
+      acc =
+        quote bind_quoted: [acc: acc, first: first, last: last, hi: hi] do
+          lo = ((first &&& 0x03) <<< 8) + last
+          [acc | <<(hi + lo)::utf8>>]
+        end
+      args = [rest, original, skip, stack, acc, 0]
       [clause] =
         quote do
           unquote(int) ->
-            codepoint =
-              <<unquote(hi)::20, unquote(lo1)::4, 0b10::2, unquote(lo2)::6>>
-            string(unquote_splicing(args), [unquote(acc) | codepoint], 0)
+            string(unquote_splicing(args))
         end
       clause
     end
 
-    defmacro escapeu_surrogate_case(int, rest, original, skip, stack, acc,
+    defmacro escapeu_surrogate(int, last, rest, original, skip, stack, acc,
              hi) do
-      clauses = escapeu_surrogate_clauses(rest, original, skip, stack, acc, hi)
+      clauses = escapeu_surrogate_clauses(last, rest, original, skip, stack, acc, hi)
       quote do
         case unquote(int) do
           unquote(clauses ++ token_error_clause(original, skip, 12))
@@ -556,18 +567,21 @@ defmodule Antidote.Parser do
     end
   end
 
-  defp escapeu(<<int::32, rest::bits>>, original, skip, stack, acc) do
+  defp escapeu(<<int1::16, int2::16, rest::bits>>, original, skip, stack,
+       acc) do
     require Unescape
-    Unescape.escapeu_case(int, rest, original, skip, stack, acc)
+    last = Unescape.escapeu_last(int2, original, skip)
+    Unescape.escapeu_first(int1, last, rest, original, skip, stack, acc)
   end
   defp escapeu(<<_rest::bits>>, original, skip, _stack, _acc) do
     error(original, skip)
   end
 
-  defp escape_surrogate(<<?\\, ?u, int::32, rest::bits>>, original, skip, stack,
-       acc, hi) do
+  defp escape_surrogate(<<?\\, ?u, int1::16, int2::16, rest::bits>>, original,
+       skip, stack, acc, hi) do
     require Unescape
-    Unescape.escapeu_surrogate_case(int, rest, original, skip, stack, acc, hi)
+    last = Unescape.escapeu_last(int2, original, skip+6)
+    Unescape.escapeu_surrogate(int1, last, rest, original, skip, stack, acc, hi)
   end
   defp escape_surrogate(<<_rest::bits>>, original, skip, _stack, _acc, _hi) do
     error(original, skip + 6)

--- a/lib/parser.ex
+++ b/lib/parser.ex
@@ -560,11 +560,17 @@ defmodule Antidote.Parser do
     require Unescape
     Unescape.escapeu_case(int, rest, original, skip, stack, acc)
   end
+  defp escapeu(<<_rest::bits>>, original, skip, _stack, _acc) do
+    error(original, skip)
+  end
 
   defp escape_surrogate(<<?\\, ?u, int::32, rest::bits>>, original, skip, stack,
        acc, hi) do
     require Unescape
     Unescape.escapeu_surrogate_case(int, rest, original, skip, stack, acc, hi)
+  end
+  defp escape_surrogate(<<_rest::bits>>, original, skip, _stack, _acc, _hi) do
+    error(original, skip + 6)
   end
 
   defp try_parse_float(string, token, skip) do

--- a/lib/parser.ex
+++ b/lib/parser.ex
@@ -440,45 +440,131 @@ defmodule Antidote.Parser do
     error(original, skip + 1)
   end
 
-  defp escapeu(<<escape::binary-4, rest::bits>>, original, skip, stack, acc) do
-    hi = try_parse_hex(escape, skip)
-    if not hi in 0xD800..0xDBFF do
-      codepoint = try_codepoint(hi, escape, skip)
-      string(rest, original, skip + 6, stack, [acc, codepoint], 0)
-    else
-      escape_surrogate(rest, original, skip, stack, acc, hi)
+  defmodule Unescape do
+
+    use Bitwise
+
+    @digits Enum.concat([?0..?9, ?A..?F, ?a..?f])
+
+    def unicode_escapes(chars1 \\ @digits, chars2 \\ @digits) do
+      for char1 <- chars1, char2 <- chars2,
+          char3 <- @digits, char4 <- @digits do
+        value = (char1 <<< 24) + (char2 <<< 16) + (char3 <<< 8) + char4
+        codepoint = (integer8(char1, char2) <<< 8) + integer8(char3, char4)
+        {value, codepoint}
+      end
+    end
+
+    defp integer8(char1, char2) do
+      (integer4(char1) <<< 4) + integer4(char2)
+    end
+
+    defp integer4(char) when char in ?0..?9, do: char - ?0
+    defp integer4(char) when char in ?A..?F, do: char - ?A + 10
+    defp integer4(char) when char in ?a..?f, do: char - ?a + 10
+
+    defp escapeu_clauses(rest, original, skip, stack, acc) do
+      for {int, codepoint} <- unicode_escapes(),
+          not (codepoint in 0xDC00..0xDFFF) do
+        escapeu_clause(int, rest, original, skip, stack, acc, codepoint)
+      end
+    end
+
+    defp escapeu_clause(int, rest, original, skip, stack, acc, codepoint)
+         when codepoint in 0xD800..0xDBFF do
+      min_char = <<(0x10000 + ((codepoint &&& 0x03FF) <<< 10))::utf8>>
+      <<hi::20, 0::4, 0b10::2, 0::6>> = min_char
+      args = [rest, original, skip, stack, acc, hi]
+      [clause] =
+        quote location: :keep do
+          unquote(int) -> escape_surrogate(unquote_splicing(args))
+        end
+      clause
+    end
+
+    defp escapeu_clause(int, rest, original, skip, stack, acc, codepoint) do
+      skip = quote do: (unquote(skip) + 6)
+      acc = quote do: [unquote(acc) | unquote(char(codepoint))]
+      args = [rest, original, skip, stack, acc, 0]
+      [clause] =
+        quote location: :keep do
+          unquote(int) -> string(unquote_splicing(args))
+        end
+      clause
+    end
+
+    defp char(codepoint) do
+      case <<codepoint::utf8>> do
+        <<byte::8>> ->
+          [byte]
+        <<byte1::8, byte2::8>> ->
+          [byte1, byte2]
+        char ->
+          char
+      end
+    end
+
+    defp token_error_clause(original, skip, len) do
+      quote do
+        _ ->
+          token_error(unquote_splicing([original, skip, len]))
+      end
+    end
+
+    defmacro escapeu_case(int, rest, original, skip, stack, acc) do
+      clauses = escapeu_clauses(rest, original, skip, stack, acc)
+      quote do
+        case unquote(int) do
+          unquote(clauses ++ token_error_clause(original, skip, 6))
+        end
+      end
+    end
+
+    defp escapeu_surrogate_clauses(rest, original, skip, stack, acc, hi) do
+      digits1 = 'Dd'
+      digits2 = Stream.concat([?C..?F, ?c..?f])
+      for {int, lo} <- unicode_escapes(digits1, digits2) do
+        escapeu_surrogate_clause(int, rest, original, skip, stack, acc, hi, lo)
+      end
+    end
+
+    defp escapeu_surrogate_clause(int, rest, original, skip, stack, acc,
+         hi, lo) do
+      skip = quote do: unquote(skip) + 12
+      args = [rest, original, skip, stack]
+      # Get the 10 least significant bits from lo and split into 4 and 6 bits
+      lo1 = (lo &&& 0x03C0) >>> 6
+      lo2 = lo &&& 0x003F
+      [clause] =
+        quote do
+          unquote(int) ->
+            codepoint =
+              <<unquote(hi)::20, unquote(lo1)::4, 0b10::2, unquote(lo2)::6>>
+            string(unquote_splicing(args), [unquote(acc) | codepoint], 0)
+        end
+      clause
+    end
+
+    defmacro escapeu_surrogate_case(int, rest, original, skip, stack, acc,
+             hi) do
+      clauses = escapeu_surrogate_clauses(rest, original, skip, stack, acc, hi)
+      quote do
+        case unquote(int) do
+          unquote(clauses ++ token_error_clause(original, skip, 12))
+        end
+      end
     end
   end
-  defp escapeu(<<_rest::bits>>, original, skip, _stack, _acc) do
-    error(original, skip + 2)
+
+  defp escapeu(<<int::32, rest::bits>>, original, skip, stack, acc) do
+    require Unescape
+    Unescape.escapeu_case(int, rest, original, skip, stack, acc)
   end
 
-  defp escape_surrogate(<<?\\, ?u, escape::binary-4, rest::bits>>, original, skip, stack, acc, hi) do
-    lo = try_parse_hex(escape, skip + 6)
-    if lo in 0xDC00..0xDFFF do
-      codepoint = 0x10000 + ((hi &&& 0x03FF) <<< 10) + (lo &&& 0x03FF)
-      string(rest, original, skip + 12, stack, [acc, <<codepoint::utf8>>], 0)
-    else
-      token = binary_part(original, skip, 12)
-      token_error(token, skip)
-    end
-  end
-  defp escape_surrogate(<<_rest::bits>>, original, skip, _stack, _acc, _hi) do
-    error(original, skip + 6)
-  end
-
-  defp try_codepoint(codepoint, string, position) do
-    <<codepoint::utf8>>
-  rescue
-    ArgumentError ->
-      token_error("\\u" <> string, position)
-  end
-
-  defp try_parse_hex(string, position) do
-    String.to_integer(string, 16)
-  rescue
-    ArgumentError ->
-      token_error("\\u" <> string, position)
+  defp escape_surrogate(<<?\\, ?u, int::32, rest::bits>>, original, skip, stack,
+       acc, hi) do
+    require Unescape
+    Unescape.escapeu_surrogate_case(int, rest, original, skip, stack, acc, hi)
   end
 
   defp try_parse_float(string, token, skip) do
@@ -498,6 +584,10 @@ defmodule Antidote.Parser do
 
   defp token_error(token, position) do
     throw {:token, token, position}
+  end
+
+  defp token_error(token, position, len) do
+    token_error(binary_part(token, position, len), position)
   end
 
   defp continue(<<rest::bits>>, original, skip, [next | stack], value) do

--- a/lib/parser.ex
+++ b/lib/parser.ex
@@ -496,11 +496,57 @@ defmodule Antidote.Parser do
       clause
     end
 
-    defp escapeu_first_clause(int, first, last, rest, original, skip, stack, acc) do
+    defp escapeu_first_clause(int, first, last, rest, original, skip, stack, acc)
+         when first <= 0x00 do
       skip = quote do: (unquote(skip) + 6)
       acc =
         quote bind_quoted: [acc: acc, first: first, last: last] do
-          [acc | <<((first <<< 8) + last)::utf8>>]
+          if last <= 0x7F do
+            # 0?????
+            [acc, last]
+          else
+            # 110xxxx??  10?????
+            byte1 = ((0b110 <<< 5) + (first <<< 2)) + (last >>> 6)
+            byte2 = (0b10 <<< 6) + (last &&& 0b111111)
+            [acc, byte1, byte2]
+          end
+        end
+      args = [rest, original, skip, stack, acc, 0]
+      [clause] =
+        quote location: :keep do
+          unquote(int) -> string(unquote_splicing(args))
+        end
+      clause
+    end
+
+    defp escapeu_first_clause(int, first, last, rest, original, skip, stack, acc)
+         when first <= 0x07 do
+      skip = quote do: (unquote(skip) + 6)
+      acc =
+        quote bind_quoted: [acc: acc, first: first, last: last] do
+          # 110xxx??  10??????
+          byte1 = ((0b110 <<< 5) + (first <<< 2)) + (last >>> 6)
+          byte2 = (0b10 <<< 6) + (last &&& 0b111111)
+          [acc, byte1, byte2]
+        end
+      args = [rest, original, skip, stack, acc, 0]
+      [clause] =
+        quote location: :keep do
+          unquote(int) -> string(unquote_splicing(args))
+        end
+      clause
+    end
+
+    defp escapeu_first_clause(int, first, last, rest, original, skip, stack, acc)
+         when first <= 0xFF do
+      skip = quote do: (unquote(skip) + 6)
+      acc =
+        quote bind_quoted: [acc: acc, first: first, last: last] do
+          # 1110xxxx  10xxxx??  10??????
+          byte1 = (0b1110 <<< 4) + (first >>> 4)
+          byte2 = ((0b10 <<< 6) + ((first &&& 0b1111) <<< 2)) + (last >>> 6)
+          byte3 = (0b10 <<< 6) + (last &&& 0b111111)
+          [acc, byte1, byte2, byte3]
         end
       args = [rest, original, skip, stack, acc, 0]
       [clause] =

--- a/lib/parser.ex
+++ b/lib/parser.ex
@@ -569,7 +569,7 @@ defmodule Antidote.Parser do
   defp escapeu(<<int1::16, int2::16, rest::bits>>, original, skip, stack,
        acc) do
     require Unescape
-    last = Unescape.escapeu_last(int2, original, skip)
+    last = escapeu_last(int2, original, skip)
     Unescape.escapeu_first(int1, last, rest, original, skip, stack, acc)
   end
   defp escapeu(<<_rest::bits>>, original, skip, _stack, _acc) do
@@ -579,11 +579,18 @@ defmodule Antidote.Parser do
   defp escape_surrogate(<<?\\, ?u, int1::16, int2::16, rest::bits>>, original,
        skip, stack, acc, hi) do
     require Unescape
-    last = Unescape.escapeu_last(int2, original, skip+6)
+    last = escapeu_last(int2, original, skip+6)
     Unescape.escapeu_surrogate(int1, last, rest, original, skip, stack, acc, hi)
   end
   defp escape_surrogate(<<_rest::bits>>, original, skip, _stack, _acc, _hi) do
     error(original, skip + 6)
+  end
+
+  @compile {:inline, escapeu_last: 3}
+
+  defp escapeu_last(int, original, skip) do
+    require Unescape
+    Unescape.escapeu_last(int, original, skip)
   end
 
   defp try_parse_float(string, token, skip) do

--- a/test/parser_test.exs
+++ b/test/parser_test.exs
@@ -41,7 +41,7 @@ defmodule Antidote.ParserTest do
     assert_fail_with ~s("Here's a snowman for you: ☃. Good day!), "unexpected end of input at position 41"
     assert_fail_with ~s("𝄞), "unexpected end of input at position 5"
     assert_fail_with ~s(\u001F), "unexpected byte at position 0: 0x1F"
-    assert_fail_with ~s("\\ud8aa\\udcxx"), "unexpected sequence at position 1: \"\\\\ud8aa\\\\udcxx\""
+    assert_fail_with ~s("\\ud8aa\\udcxx"), "unexpected sequence at position 7: \"\\\\udcxx\""
     assert_fail_with ~s("\\ud8aa\\uda00"), "unexpected sequence at position 1: \"\\\\ud8aa\\\\uda00\""
     assert_fail_with ~s("\\uxxxx"), "unexpected sequence at position 1: \"\\\\uxxxx\""
 

--- a/test/parser_test.exs
+++ b/test/parser_test.exs
@@ -41,7 +41,7 @@ defmodule Antidote.ParserTest do
     assert_fail_with ~s("Here's a snowman for you: ☃. Good day!), "unexpected end of input at position 41"
     assert_fail_with ~s("𝄞), "unexpected end of input at position 5"
     assert_fail_with ~s(\u001F), "unexpected byte at position 0: 0x1F"
-    assert_fail_with ~s("\\ud8aa\\udcxx"), "unexpected sequence at position 7: \"\\\\udcxx\""
+    assert_fail_with ~s("\\ud8aa\\udcxx"), "unexpected sequence at position 1: \"\\\\ud8aa\\\\udcxx\""
     assert_fail_with ~s("\\ud8aa\\uda00"), "unexpected sequence at position 1: \"\\\\ud8aa\\\\uda00\""
     assert_fail_with ~s("\\uxxxx"), "unexpected sequence at position 1: \"\\\\uxxxx\""
 


### PR DESCRIPTION
Optimizes the unescaping unicode characters in strings by matching on precalculated pairs of characters as 16 bit integers, and using bit shifting to create a codepoint with the value of both pairs, or 4 pairs for surrogates. As much bit shifting is carried out at compile time as possible.

It might be possible match on more than 2 characters at a time but it does not appear to improve performance and increases compile significantly.