### PR TITLE
Add strings: :copy configuration for parser

### DIFF
--- a/lib/antidote.ex
+++ b/lib/antidote.ex
@@ -22,10 +22,15 @@ defmodule Antidote do
       * `:strings` (default) - decodes keys as binary strings,
       * `:atoms` - keys are converted to atoms using `String.to_atom/1`,
       * `:atoms!` - keys are converted to atoms using `String.to_existing_atom/1`,
-      * `:copy` - decodes keys as binary strings and makes sure they don't reference
-        the original binary using `:binary.copy/1`
       * custom decoder - additionally a function accepting a string and returning a key
         is accepted.
+
+    * `:strings` - controls how strings (including keys) are decoded. Possible values are:
+
+      * `:reference` (default) - when possible tries to create a sub-binary into the original
+      * `:copy` - always copies the strings. This option is especially useful when parts of the
+        decoded data will be stored for a long time (in ets or some process) to avoid keeping
+        the reference to the original data.
 
   ## Decoding keys to atoms
 
@@ -134,6 +139,6 @@ defmodule Antidote do
   end
 
   defp format_decode_opts(opts) do
-    Enum.into(opts, %{keys: :strings})
+    Enum.into(opts, %{keys: :strings, strings: :reference})
   end
 end

--- a/test/parser_test.exs
+++ b/test/parser_test.exs
@@ -85,18 +85,22 @@ defmodule Antidote.ParserTest do
     assert parse!(~s({"#{key}": "value"}), keys: :atoms) == %{key => "value"}
   end
 
-  test "copying keys on decode" do
-    assert parse!("{}", keys: :copy) == %{}
-
-    # Regular decode references the original string
-    assert [{key, "bar"}] = Map.to_list(parse!(~s({"foo": "bar"})))
-    assert key == "foo"
-    assert :binary.referenced_byte_size(key) == 14
+  test "copying strings on decode" do
+    assert parse!("{}", strings: :copy) == %{}
 
     # Copy decode, copies the key
-    assert [{key, "bar"}] = Map.to_list(parse!(~s({"foo": "bar"}), keys: :copy))
+    assert [{key, value}] = Map.to_list(parse!(~s({"foo": "bar"}), strings: :copy))
     assert key == "foo"
+    assert value == "bar"
     assert :binary.referenced_byte_size(key) == 3
+    assert :binary.referenced_byte_size(value) == 3
+
+    # Regular decode references the original string
+    assert [{key, value}] = Map.to_list(parse!(~s({"foo": "bar"})))
+    assert key == "foo"
+    assert value == "bar"
+    assert :binary.referenced_byte_size(key) == 14
+    assert :binary.referenced_byte_size(value) == 14
   end
 
   test "custom object key mapping function" do


### PR DESCRIPTION
Closes #4

Benchmarks show that adding this feature (but not using it) adds about 2-5% overhead. I think this is acceptable.