### PR TITLE
Add value and decoded types and typedocs.

### DIFF
--- a/lib/jason.ex
+++ b/lib/jason.ex
@@ -29,6 +29,8 @@ defmodule Jason do
   @type value :: nil | String.t() | number | boolean | [value] | %{String.t() => value}
   @typedoc "A decoded JSON value where map keys can have any type."
   @type decoded :: [decoded] | %{map_key => decoded} | value
+  @typedoc "The types that may be encoded. Only tuples are not included."
+  @type encodable :: decoded | atom
 
   @doc """
   Parses a JSON value from `input` iodata.
@@ -143,7 +145,7 @@ defmodule Jason do
       {:error, %Jason.EncodeError{message: "invalid byte 0xFF in <<255>>"}}
 
   """
-  @spec encode(decoded, [encode_opt]) ::
+  @spec encode(encodable, [encode_opt]) ::
           {:ok, String.t()} | {:error, EncodeError.t() | Exception.t()}
   def encode(input, opts \\ []) do
     case do_encode(input, format_encode_opts(opts)) do
@@ -167,7 +169,7 @@ defmodule Jason do
       ** (Jason.EncodeError) invalid byte 0xFF in <<255>>
 
   """
-  @spec encode!(decoded, [encode_opt]) :: String.t() | no_return
+  @spec encode!(encodable, [encode_opt]) :: String.t() | no_return
   def encode!(input, opts \\ []) do
     case do_encode(input, format_encode_opts(opts)) do
       {:ok, result} -> IO.iodata_to_binary(result)
@@ -194,7 +196,7 @@ defmodule Jason do
       {:error, %Jason.EncodeError{message: "invalid byte 0xFF in <<255>>"}}
 
   """
-  @spec encode_to_iodata(decoded, [encode_opt]) ::
+  @spec encode_to_iodata(encodable, [encode_opt]) ::
           {:ok, iodata} | {:error, EncodeError.t() | Exception.t()}
   def encode_to_iodata(input, opts \\ []) do
     do_encode(input, format_encode_opts(opts))
@@ -216,7 +218,7 @@ defmodule Jason do
       ** (Jason.EncodeError) invalid byte 0xFF in <<255>>
 
   """
-  @spec encode_to_iodata!(decoded, [encode_opt]) :: iodata | no_return
+  @spec encode_to_iodata!(encodable, [encode_opt]) :: iodata | no_return
   def encode_to_iodata!(input, opts \\ []) do
     case do_encode(input, format_encode_opts(opts)) do
       {:ok, result} -> result

--- a/lib/jason.ex
+++ b/lib/jason.ex
@@ -13,7 +13,7 @@ defmodule Jason do
   @type encode_opt :: {:escape, escape} | {:maps, maps} | {:pretty, boolean | Formatter.opts()}
 
   @typedoc "Decoding setting for map keys."
-  @type keys :: :atoms | :atoms! | :strings | :copy | (binary -> term)
+  @type keys :: :atoms | :atoms! | :strings | :copy | (String.t() -> term)
   @typedoc "Decoding setting for strings."
   @type strings :: :reference | :copy
   @typedoc "Decoding setting for floats."
@@ -24,7 +24,7 @@ defmodule Jason do
   @type decode_opt :: {:keys, keys} | {:strings, strings} | {:floats, floats} | {:objects, objects}
 
   @typedoc "A plain JSON value where map keys can only be strings."
-  @type value :: nil | binary | number | boolean | [value] | %{binary => value}
+  @type value :: nil | String.t() | number | boolean | [value] | %{String.t() => value}
   @typedoc "A decoded JSON value where map keys can have any type."
   @type decoded :: [decoded] | %{term => decoded} | value
 
@@ -142,7 +142,7 @@ defmodule Jason do
 
   """
   @spec encode(decoded, [encode_opt]) ::
-          {:ok, binary} | {:error, EncodeError.t() | Exception.t()}
+          {:ok, String.t()} | {:error, EncodeError.t() | Exception.t()}
   def encode(input, opts \\ []) do
     case do_encode(input, format_encode_opts(opts)) do
       {:ok, result} -> {:ok, IO.iodata_to_binary(result)}
@@ -165,7 +165,7 @@ defmodule Jason do
       ** (Jason.EncodeError) invalid byte 0xFF in <<255>>
 
   """
-  @spec encode!(decoded, [encode_opt]) :: binary | no_return
+  @spec encode!(decoded, [encode_opt]) :: String.t() | no_return
   def encode!(input, opts \\ []) do
     case do_encode(input, format_encode_opts(opts)) do
       {:ok, result} -> IO.iodata_to_binary(result)

--- a/lib/jason.ex
+++ b/lib/jason.ex
@@ -25,11 +25,15 @@ defmodule Jason do
   @typedoc "Available decoding options."
   @type decode_opt :: {:keys, keys} | {:strings, strings} | {:floats, floats} | {:objects, objects}
 
-  @typedoc "A plain JSON value where map keys can only be strings."
-  @type value :: nil | String.t() | number | boolean | [value] | %{String.t() => value}
+  @typedoc "A plain JSON object where keys can only be strings."
+  @type object :: %{String.t() => value}
+  @typedoc "A plain JSON array."
+  @type array :: [value]
+  @typedoc "A plain JSON value."
+  @type value :: nil | String.t() | number | boolean | array | object
   @typedoc "A decoded JSON value where map keys can have any type."
   @type decoded :: [decoded] | %{map_key => decoded} | value
-  @typedoc "The map key types that can be encoded."
+  @typedoc "The type of map keys that can be encoded."
   @type encodable_key :: String.t() | number | atom | [encodable_key]
   @typedoc "The types that can be encoded. Not included are: `tuple`s, `function`s, `reference`s, `port`s and `pid`s."
   @type encodable :: String.t() | number | atom | [encodable] | %{encodable_key => encodable}

--- a/lib/jason.ex
+++ b/lib/jason.ex
@@ -12,8 +12,10 @@ defmodule Jason do
   @typedoc "Available encoding options."
   @type encode_opt :: {:escape, escape} | {:maps, maps} | {:pretty, boolean | Formatter.opts()}
 
+  @typedoc "The type of the value returned by the custom decoder function."
+  @type map_key :: term
   @typedoc "Decoding setting for map keys."
-  @type keys :: :atoms | :atoms! | :strings | :copy | (String.t() -> term)
+  @type keys :: :atoms | :atoms! | :strings | :copy | (String.t() -> map_key)
   @typedoc "Decoding setting for strings."
   @type strings :: :reference | :copy
   @typedoc "Decoding setting for floats."
@@ -26,7 +28,7 @@ defmodule Jason do
   @typedoc "A plain JSON value where map keys can only be strings."
   @type value :: nil | String.t() | number | boolean | [value] | %{String.t() => value}
   @typedoc "A decoded JSON value where map keys can have any type."
-  @type decoded :: [decoded] | %{term => decoded} | value
+  @type decoded :: [decoded] | %{map_key => decoded} | value
 
   @doc """
   Parses a JSON value from `input` iodata.
@@ -38,7 +40,7 @@ defmodule Jason do
       * `:strings` (default) - decodes keys as binary strings,
       * `:atoms` - keys are converted to atoms using `String.to_atom/1`,
       * `:atoms!` - keys are converted to atoms using `String.to_existing_atom/1`,
-      * custom decoder - additionally a function accepting a string and returning a key
+      * `fn s -> s end` - additionally a custom decoder function accepting a string and returning a key
         is accepted.
 
     * `:strings` - controls how strings (including keys) are decoded. Possible values are:

--- a/lib/jason.ex
+++ b/lib/jason.ex
@@ -15,7 +15,7 @@ defmodule Jason do
   @typedoc "The type of the value returned by the custom decoder function."
   @type map_key :: term
   @typedoc "Decoding setting for map keys."
-  @type keys :: :atoms | :atoms! | :strings | :copy | (String.t() -> map_key)
+  @type keys :: :atoms | :atoms! | :strings | :copy | (key :: String.t() -> map_key)
   @typedoc "Decoding setting for strings."
   @type strings :: :reference | :copy
   @typedoc "Decoding setting for floats."
@@ -29,8 +29,10 @@ defmodule Jason do
   @type value :: nil | String.t() | number | boolean | [value] | %{String.t() => value}
   @typedoc "A decoded JSON value where map keys can have any type."
   @type decoded :: [decoded] | %{map_key => decoded} | value
-  @typedoc "The types that may be encoded. Only tuples are not included."
-  @type encodable :: decoded | atom
+  @typedoc "The map key types that can be encoded."
+  @type encodable_key :: String.t() | number | atom | [encodable_key]
+  @typedoc "The types that can be encoded. Not included are: `tuple`s, `function`s, `reference`s, `port`s and `pid`s."
+  @type encodable :: String.t() | number | atom | [encodable] | %{encodable_key => encodable}
 
   @doc """
   Parses a JSON value from `input` iodata.


### PR DESCRIPTION
Hi!

I'd like to propose adding two types. Namely `value` and `decoded`. I sometimes noticed that it would be great to have a JSON value type handy, when I was dealing with JSON data. I'm sure others would benefit as well when they can refer to a canonical type from the most popular JSON Elixir library itself (e.g. `@spec f(Jason.value()) :: Jason.value()`).

I gave the input parameters the `decoded` type so that dialyzer may catch instances where developers unknowingly pass a tuple to the encode functions. But I'm not sure if that really helps or if it will be more of a hindrance.

I distinguish the `value` type from the `decoded` type, which can have any kind of map keys, so that we can have a stricter and more basic type when we're dealing with JSON data. :+1:

PS: You'll notice I changed `String.t()` to `binary`. It's a matter of preference to me and we can change it back to `String.t()` of course.