### PR TITLE
Reorder & normalize Changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,7 @@
 
 ## 1.5.0-alpha.2 (07.07.2023)
 
-* Add limit to decoded integer sizes of 1024 digits. This can be changed
-  with the `decoding_integer_digit_limit` app env config.
-
-## 1.4.1 (06.07.2023)
+### Enhancements
 
 * Add limit to decoded integer sizes of 1024 digits. This can be changed
   with the `decoding_integer_digit_limit` app env config.
@@ -16,6 +13,13 @@
 
 * Add optional dependency for [`jason_native`](https://github.com/spawnfest/json_native).
   Please refer to the repo for usage instructions
+
+## 1.4.1 (06.07.2023)
+
+### Enhancements
+
+* Add limit to decoded integer sizes of 1024 digits. This can be changed
+  with the `decoding_integer_digit_limit` app env config.
 
 ## 1.4.0 (12.09.2022)
 


### PR DESCRIPTION
* ordered changelog by version number, not sure if there is a general rule but having 1.4.1 inbetween the two 1.5 alpha releases felt weird
* standardized the format, so that it has "Enhancements" like the previous releases