### PR TITLE
Fix warnings by conditionally compiling Decimal support

### DIFF
--- a/lib/decoder.ex
+++ b/lib/decoder.ex
@@ -86,15 +86,18 @@ defmodule Jason.Decoder do
     end
   end
 
-  defp float_decode_function(%{floats: :decimals}) do
-    fn string, token, skip ->
-      # silence xref warning
-      decimal = Decimal
-      try do
-        decimal.new(string)
-      rescue
-        Decimal.Error ->
-          token_error(token, skip)
+  if Code.ensure_loaded?(Decimal) do
+    defp float_decode_function(%{floats: :decimals}) do
+      fn string, token, skip ->
+        # silence xref warning
+        decimal = Decimal
+
+        try do
+          decimal.new(string)
+        rescue
+          Decimal.Error ->
+            token_error(token, skip)
+        end
       end
     end
   end

--- a/lib/decoder.ex
+++ b/lib/decoder.ex
@@ -89,11 +89,8 @@ defmodule Jason.Decoder do
   if Code.ensure_loaded?(Decimal) do
     defp float_decode_function(%{floats: :decimals}) do
       fn string, token, skip ->
-        # silence xref warning
-        decimal = Decimal
-
         try do
-          decimal.new(string)
+          Decimal.new(string)
         rescue
           Decimal.Error ->
             token_error(token, skip)

--- a/lib/decoder.ex
+++ b/lib/decoder.ex
@@ -97,6 +97,10 @@ defmodule Jason.Decoder do
         end
       end
     end
+  else
+    defp float_decode_function(%{floats: :decimals}) do
+      raise ArgumentError, "decimal library not found, :decimals option not available"
+    end
   end
 
   defp value(data, original, skip, stack, decode) do

--- a/lib/encode.ex
+++ b/lib/encode.ex
@@ -256,10 +256,12 @@ defmodule Jason.Encode do
     end
   end
 
-  defp struct(value, _escape, _encode_map, Decimal) do
-    # silence the xref warning
-    decimal = Decimal
-    [?", decimal.to_string(value, :normal), ?"]
+  if Code.ensure_loaded?(Decimal) do
+    defp struct(value, _escape, _encode_map, Decimal) do
+      # silence the xref warning
+      decimal = Decimal
+      [?", decimal.to_string(value, :normal), ?"]
+    end
   end
 
   defp struct(value, escape, encode_map, Fragment) do

--- a/lib/encode.ex
+++ b/lib/encode.ex
@@ -258,9 +258,7 @@ defmodule Jason.Encode do
 
   if Code.ensure_loaded?(Decimal) do
     defp struct(value, _escape, _encode_map, Decimal) do
-      # silence the xref warning
-      decimal = Decimal
-      [?", decimal.to_string(value, :normal), ?"]
+      [?", Decimal.to_string(value, :normal), ?"]
     end
   end
 

--- a/lib/encoder.ex
+++ b/lib/encoder.ex
@@ -227,9 +227,7 @@ end
 if Code.ensure_loaded?(Decimal) do
   defimpl Jason.Encoder, for: Decimal do
     def encode(value, _opts) do
-      # silence the xref warning
-      decimal = Decimal
-      [?", decimal.to_string(value), ?"]
+      [?", Decimal.to_string(value), ?"]
     end
   end
 end

--- a/lib/encoder.ex
+++ b/lib/encoder.ex
@@ -224,11 +224,13 @@ defimpl Jason.Encoder, for: [Date, Time, NaiveDateTime, DateTime] do
   end
 end
 
-defimpl Jason.Encoder, for: Decimal do
-  def encode(value, _opts) do
-    # silence the xref warning
-    decimal = Decimal
-    [?", decimal.to_string(value), ?"]
+if Code.ensure_loaded?(Decimal) do
+  defimpl Jason.Encoder, for: Decimal do
+    def encode(value, _opts) do
+      # silence the xref warning
+      decimal = Decimal
+      [?", decimal.to_string(value), ?"]
+    end
   end
 end
 


### PR DESCRIPTION
This fixes the following Elixir 1.17 warnings when `:decimal` isn't
included in the dependency list:

```
==> jason
    warning: Decimal.new/1 is undefined (module Decimal is not available or is yet to be defined)
    │
 94 │         decimal.new(string)
    │                 ~
    │
    └─ (jason 1.4.3) lib/decoder.ex:94:17: Jason.Decoder.float_decode_function/1

warning: struct Decimal.Error is undefined (module Decimal.Error is not available or is yet to be defined)
└─ (jason 1.4.3) lib/decoder.ex: Jason.Decoder.float_decode_function/1

     warning: Decimal.to_string/2 is undefined (module Decimal is not available or is yet to be defined)
     │
 242 │     [?", decimal.to_string(value, :normal), ?"]
     │                  ~
     │
     └─ (jason 1.4.3) lib/encode.ex:242:18: Jason.Encode.struct/4

     warning: Decimal.to_string/1 is undefined (module Decimal is not available or is yet to be defined)
     │
 231 │     [?", decimal.to_string(value), ?"]
     │                  ~
     │
     └─ (jason 1.4.3) lib/encoder.ex:231:18: Jason.Encoder.Decimal.encode/2
```
