### PR TITLE
fix broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Jason is usually only twice as slow.
 
 Both parser and generator fully conform to
 [RFC 8259](https://tools.ietf.org/html/rfc8259) and
-[ECMA 404](http://www.ecma-international.org/publications/standards/Ecma-404.htm)
+[ECMA 404](https://ecma-international.org/publications-and-standards/standards/ecma-404/)
 standards. The parser is tested using [JSONTestSuite](https://github.com/nst/JSONTestSuite).
 
 ## Installation


### PR DESCRIPTION
The ecma-international link is fixed and also `http` -> `https` is changed.