### PR TITLE
Allow deriving Jason.Encoder with sorted keys

### DIFF
--- a/lib/encoder.ex
+++ b/lib/encoder.ex
@@ -10,6 +10,7 @@ defprotocol Jason.Encoder do
 
     * `:only` - encodes only values of specified keys.
     * `:except` - encodes all struct fields except specified keys.
+    * `:sort_keys` - sorts the keys, optionally with a custom function.
 
   By default all keys except the `:__struct__` key are encoded.
 
@@ -50,6 +51,13 @@ defprotocol Jason.Encoder do
 
   The actually generated implementations are more efficient computing some data
   during compilation similar to the macros from the `Jason.Helpers` module.
+
+  ## Sorting keys
+
+  You can also sort the keys in the output JSON, either according to Erlang's
+  term ordering with `@derive {Jason.Encoder, sort_keys: true}` or using a custom
+  sort function (as passed to `Enum.sort/2`) e.g.
+  `@derive {Jason.Encoder, sort_keys: &(&1>=&2)}`
 
   ## Explicit implementation
 
@@ -127,17 +135,6 @@ defimpl Jason.Encoder, for: Any do
 
           Protocol.derive(Jason.Encoder, NameOfTheStruct, only: [...])
           Protocol.derive(Jason.Encoder, NameOfTheStruct)
-
-      You can also sort the keys in the output JSON, either according to \
-      Erlang's term ordering:
-
-          @derive {Jason.Encoder, sort_keys: true}
-          defstruct ...
-
-      Or using a custom sort function, as passed to `Enum.sort/2`:
-
-          @derive {Jason.Encoder, sort_keys: &(&1>=&2)}
-          defstruct ...
       """
   end
 

--- a/test/encode_test.exs
+++ b/test/encode_test.exs
@@ -135,6 +135,18 @@ defmodule Jason.EncoderTest do
     defstruct name: "", size: 0
   end
 
+  defmodule DerivedUsingSortKeys do
+    @derive {Encoder, sort_keys: true}
+    defstruct a: 1, b: "", c: nil, d: 4
+  end
+
+
+  defmodule DerivedUsingCustomSortKeys do
+    @derive {Encoder, sort_keys: &(&1>=&2)}
+    defstruct a: 1, b: "", c: nil, d: 4
+  end
+
+
   defmodule DerivedWeirdKey do
     @derive Encoder
     defstruct [:_]
@@ -159,6 +171,12 @@ defmodule Jason.EncoderTest do
 
     derived_using_except = %DerivedUsingExcept{name: "derived using :except", size: 10}
     assert to_json(derived_using_except) == ~s({"size":10})
+
+    derived_using_sort_keys = %DerivedUsingSortKeys{}
+    assert to_json(derived_using_sort_keys) == ~s({"a":1,"b":"","c":null,"d":4})
+
+    derived_using_custom_sort_keys = %DerivedUsingCustomSortKeys{}
+    assert to_json(derived_using_custom_sort_keys) == ~s({"d":4,"c":null,"b":"","a":1})
 
     derived_weird_key = %DerivedWeirdKey{}
     assert to_json(derived_weird_key) == ~s({"_":null})


### PR DESCRIPTION
I think this closes #170, but rather than making a change to pretty_print, I modified `@derive Jasen.Encoder`