### PR TITLE
CI: Update Elixir & OTP build matrix, support old OTP versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,9 @@ jobs:
             os: ubuntu-22.04
           - elixir: 1.16.x
             otp: 26
+            os: ubuntu-22.04
+          - elixir: 1.17.x
+            otp: 27
             os: ubuntu-latest
             warnings_as_errors: true
     env:
@@ -97,8 +100,8 @@ jobs:
       - uses: actions/checkout@v2
       - uses: erlef/setup-beam@v1
         with:
-          otp-version: 26
-          elixir-version: 1.16.x
+          otp-version: 27
+          elixir-version: 1.17.x
       - name: Install Dependencies
         run: |
           mix local.hex --force

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,59 +15,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - elixir: 1.4.x
-            otp: 20
-            os: ubuntu-20.04
-            gcc: gcc-10
-            gpp: g++-10
-          - elixir: 1.5.x
-            otp: 20
-            os: ubuntu-20.04
-            gcc: gcc-10
-            gpp: g++-10
-          - elixir: 1.6.x
-            otp: 20
-            os: ubuntu-20.04
-            gcc: gcc-10
-            gpp: g++-10
-          - elixir: 1.7.x
-            otp: 20
-            os: ubuntu-20.04
-            gcc: gcc-10
-            gpp: g++-10
-          - elixir: 1.8.x
-            otp: 20
-            os: ubuntu-20.04
-            gcc: gcc-10
-            gpp: g++-10
-          - elixir: 1.9.x
-            otp: 20
-            os: ubuntu-20.04
-            gcc: gcc-10
-            gpp: g++-10
-          - elixir: 1.10.x
-            otp: 21
-            os: ubuntu-20.04
-            gcc: gcc-10
-            gpp: g++-10
-          - elixir: 1.11.x
-            otp: 22
-            os: ubuntu-20.04
-            gcc: gcc-10
-            gpp: g++-10
-          - elixir: 1.11.x
-            otp: 23
-            os: ubuntu-20.04
-            gcc: gcc-10
-            gpp: g++-10
-          - elixir: 1.12.x
-            otp: 23
-            os: ubuntu-20.04
-            gcc: gcc-10
-            gpp: g++-10
           - elixir: 1.13.x
             otp: 24
-            os: ubuntu-20.04
+            os: ubuntu-22.04
             gcc: gcc-10
             gpp: g++-10
           - elixir: 1.14.x
@@ -126,6 +76,66 @@ jobs:
         env:
           CC: ${{matrix.gcc}}
           CXX: ${{matrix.gpp}}
+  mix_test_even_older:
+    name: mix test (Elixir ${{matrix.elixir}} | OTP ${{matrix.otp}})
+    runs-on: ubuntu-latest
+    container:
+      image: ubuntu:focal-20250404
+      env:
+        ImageOS: ubuntu20
+        MIX_ENV: test
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - elixir: 1.4.x
+            otp: 20
+          - elixir: 1.5.x
+            otp: 20
+          - elixir: 1.6.x
+            otp: 20
+          - elixir: 1.7.x
+            otp: 20
+          - elixir: 1.8.x
+            otp: 20
+          - elixir: 1.9.x
+            otp: 20
+          - elixir: 1.10.x
+            otp: 21
+          - elixir: 1.11.x
+            otp: 22
+          - elixir: 1.11.x
+            otp: 23
+          - elixir: 1.12.x
+            otp: 23
+    steps:
+      # Needed by erlef/setup-beam action
+      - run: |
+          apt update -qqy
+          apt install -qqy build-essential libssl-dev unzip
+      - uses: actions/checkout@v2
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: ${{matrix.otp}}
+          elixir-version: ${{matrix.elixir}}
+      - name: Install Dependencies
+        run: |
+          mix local.hex --force
+          mix local.rebar --force
+          mix deps.get --only test
+      - name: Cache build artifacts
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.hex
+            ~/.mix
+            _build
+          key: ${{ matrix.otp }}-${{ matrix.elixir }}-build
+      - run: mix compile
+        env:
+          CC: gcc-9
+          CXX: g++-9
+      - run: mix test
   dialyzer:
     name: mix dialyzer
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
             otp: 26
             os: ubuntu-22.04
           - elixir: 1.16.x
-            otp: 27
+            otp: 26
             os: ubuntu-latest
             warnings_as_errors: true
     env:
@@ -97,7 +97,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: erlef/setup-beam@v1
         with:
-          otp-version: 27
+          otp-version: 26
           elixir-version: 1.16.x
       - name: Install Dependencies
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,11 @@ jobs:
             gpp: g++-11
           - elixir: 1.17.x
             otp: 27
+            os: ubuntu-24.04
+            gcc: gcc-13
+            gpp: g++-13
+          - elixir: 1.18.x
+            otp: 27
             os: ubuntu-latest
             gcc: gcc-13
             gpp: g++-13
@@ -130,8 +135,8 @@ jobs:
       - uses: actions/checkout@v2
       - uses: erlef/setup-beam@v1
         with:
+          elixir-version: 1.18.x
           otp-version: 27
-          elixir-version: 1.17.x
       - name: Install Dependencies
         run: |
           mix local.hex --force

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,9 @@ jobs:
             os: ubuntu-22.04
           - elixir: 1.15.x
             otp: 26
+            os: ubuntu-22.04
+          - elixir: 1.16.x
+            otp: 27
             os: ubuntu-latest
             warnings_as_errors: true
     env:
@@ -94,8 +97,8 @@ jobs:
       - uses: actions/checkout@v2
       - uses: erlef/setup-beam@v1
         with:
-          otp-version: 26
-          elixir-version: 1.15.x
+          otp-version: 27
+          elixir-version: 1.16.x
       - name: Install Dependencies
         run: |
           mix local.hex --force

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,48 +18,78 @@ jobs:
           - elixir: 1.4.x
             otp: 20
             os: ubuntu-20.04
+            gcc: gcc-10
+            gpp: g++-10
           - elixir: 1.5.x
             otp: 20
             os: ubuntu-20.04
+            gcc: gcc-10
+            gpp: g++-10
           - elixir: 1.6.x
             otp: 20
             os: ubuntu-20.04
+            gcc: gcc-10
+            gpp: g++-10
           - elixir: 1.7.x
             otp: 20
             os: ubuntu-20.04
+            gcc: gcc-10
+            gpp: g++-10
           - elixir: 1.8.x
             otp: 20
             os: ubuntu-20.04
+            gcc: gcc-10
+            gpp: g++-10
           - elixir: 1.9.x
             otp: 20
             os: ubuntu-20.04
+            gcc: gcc-10
+            gpp: g++-10
           - elixir: 1.10.x
             otp: 21
             os: ubuntu-20.04
+            gcc: gcc-10
+            gpp: g++-10
           - elixir: 1.11.x
             otp: 22
             os: ubuntu-20.04
+            gcc: gcc-10
+            gpp: g++-10
           - elixir: 1.11.x
             otp: 23
             os: ubuntu-20.04
+            gcc: gcc-10
+            gpp: g++-10
           - elixir: 1.12.x
             otp: 23
             os: ubuntu-20.04
+            gcc: gcc-10
+            gpp: g++-10
           - elixir: 1.13.x
             otp: 24
             os: ubuntu-20.04
+            gcc: gcc-10
+            gpp: g++-10
           - elixir: 1.14.x
             otp: 25
             os: ubuntu-22.04
+            gcc: gcc-11
+            gpp: g++-11
           - elixir: 1.15.x
             otp: 26
             os: ubuntu-22.04
+            gcc: gcc-11
+            gpp: g++-11
           - elixir: 1.16.x
             otp: 26
             os: ubuntu-22.04
+            gcc: gcc-11
+            gpp: g++-11
           - elixir: 1.17.x
             otp: 27
             os: ubuntu-latest
+            gcc: gcc-13
+            gpp: g++-13
             warnings_as_errors: true
     env:
       MIX_ENV: test
@@ -85,12 +115,12 @@ jobs:
       - run: mix compile --warnings-as-errors
         if: matrix.warnings_as_errors
         env:
-          CC: gcc-10
-          CXX: g++-10
+          CC: ${{matrix.gcc}}
+          CXX: ${{matrix.gpp}}
       - run: mix test
         env:
-          CC: gcc-10
-          CXX: g++-10
+          CC: ${{matrix.gcc}}
+          CXX: ${{matrix.gpp}}
   dialyzer:
     name: mix dialyzer
     runs-on: ubuntu-latest


### PR DESCRIPTION
💁 These changes update the the matrix of versions used in continuous integration to include:
- Elixir 1.16, 1.17 and 1.18
- OTP 27

I've followed the existing pattern of incrementing the Elixir minor version in lockstep with the most recent major version of Erlang/OTP that's supported by that Elixir version.

⚠️ The other significant part of these changes is to mitigate GitHub's recent retirement of `ubuntu-20.04` as a runner image which can't be used by a GitHub Actions workflow job any more.
```
This is a scheduled Ubuntu 20.04 retirement. Ubuntu 20.04 LTS runner will be removed on 2025-04-15. For more details, see https://github.com/actions/runner-images/issues/11101
```
To minimise the size of changes I've split the original test job into 2 separate jobs:
- the original one, without OTP <= v23.
- a new one with a matrix of those older OTP versions that runs inside a [dedicated Ubuntu 20.04 container](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idcontainer).