### PR TITLE
Add example/doctest for Jason.OrderedObject.new/1

### DIFF
--- a/lib/ordered_object.ex
+++ b/lib/ordered_object.ex
@@ -15,6 +15,18 @@ defmodule Jason.OrderedObject do
 
   defstruct values: []
 
+  @doc ~S"""
+  Creates a new ordered object from a list of key-value pairs.
+
+  ## Example
+
+      iex> %{a: 1, c: 3, b: 2}
+      ...> |> Enum.sort()
+      ...> |> Jason.OrderedObject.new()
+      ...> |> Jason.encode!()
+      "{\"a\":1,\"b\":2,\"c\":3}"
+
+  """
   def new(values) when is_list(values) do
     %__MODULE__{values: values}
   end

--- a/test/ordered_object_test.exs
+++ b/test/ordered_object_test.exs
@@ -3,6 +3,8 @@ defmodule Jason.OrderedObjectTest do
 
   alias Jason.OrderedObject
 
+  doctest Jason.OrderedObject
+
   test "Access behavior" do
     obj = OrderedObject.new([{:foo, 1}, {"bar", 2}])
 


### PR DESCRIPTION
I had trouble finding an example of how to use `Jason.OrderedObject.new/1`, so I made an example/doctest which shows how to use it.

NOTE: I would like to justify the contrived example I used. It reflects the scenario that I always find myself needing when I want to sort a JSON object, which is that I need the keys to appear in alphabetical order. I realize that alphabetization is not part of the JSON spec, but it is still a helpful feature to have when reading large, complicated JSON objects. The inherent non-sorted nature of Elixir maps can lead to a situation where trying to find a key in a JSON object is like trying to find a needle in a haystack. This example provides a real-world example of how I (and probably others) would need to use this function.