### PR TITLE
Improve Jason.Encoder derive option errors

### DIFF
--- a/lib/encoder.ex
+++ b/lib/encoder.ex
@@ -75,6 +75,8 @@ defprotocol Jason.Encoder do
 end
 
 defimpl Jason.Encoder, for: Any do
+  @derive_options [:only, :except]
+
   defmacro __deriving__(module, struct, opts) do
     fields = fields_to_encode(struct, opts)
     kv = Enum.map(fields, &{&1, generated_var(&1)})
@@ -138,6 +140,8 @@ defimpl Jason.Encoder, for: Any do
   end
 
   defp fields_to_encode(struct, opts) do
+    validate_deriving_options!(opts)
+
     fields = Map.keys(struct)
 
     cond do
@@ -167,6 +171,18 @@ defimpl Jason.Encoder, for: Any do
 
       true ->
         fields -- [:__struct__]
+    end
+  end
+
+  defp validate_deriving_options!(opts) do
+    case Keyword.keys(opts) -- @derive_options do
+      [] ->
+        :ok
+
+      invalid_options ->
+        raise ArgumentError,
+              "invalid option(s) for deriving Jason.Encoder: #{inspect(invalid_options)}. " <>
+                "Accepted options are :only and :except"
     end
   end
 end

--- a/test/encode_test.exs
+++ b/test/encode_test.exs
@@ -190,6 +190,21 @@ defmodule Jason.EncoderTest do
     end
   end
 
+  test "@derive validate options" do
+    message =
+      "invalid option(s) for deriving Jason.Encoder: [:invalid]. " <>
+        "Accepted options are :only and :except"
+
+    assert_raise ArgumentError, message, fn ->
+      Code.eval_string("""
+      defmodule InvalidDeriveOption do
+        @derive {Jason.Encoder, invalid: [:__meta__]}
+        defstruct [:__meta__, :name]
+      end
+      """)
+    end
+  end
+
   defmodule KeywordTester do
     defstruct [:baz, :foo, :quux]
   end


### PR DESCRIPTION
## Summary
- reject unknown options passed when deriving Jason.Encoder
- raise a compile-time ArgumentError listing the accepted :only and :except options
- cover the invalid option case from the issue with a regression test

Fixes #183

## Validation
- mix test test/encode_test.exs
- mix test

Note: mix format --check-formatted lib/encoder.ex test/encode_test.exs was attempted but the local Elixir 1.19 formatter wants to rewrite pre-existing project formatting across these files, so I kept the diff scoped.